### PR TITLE
upgrade generic-pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Usage
 
 ```js
 var r    = require('rethinkdb')
-var Pool = require('rethinkdb-pool')
-var pool = Pool(r, {
+var createPool = require('rethinkdb-pool')
+var pool = createPool(r, {
   host:'localhost',
   port:28015,
   db:'marvel',

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Usage
 ## Create pool
 
 ```js
-var r    = require('rethinkdb')
+var r = require('rethinkdb')
 var createPool = require('rethinkdb-pool')
 var pool = createPool(r, {
   host:'localhost',
@@ -48,11 +48,13 @@ pool.run(query).then(function (list) {
 
 ## Acquire / release resources
 
+Connection can be acquired by calling the `.acquire()` function, but the responsibility of managing resources can be quite challenging.
+
+See: http://bluebirdjs.com/docs/api/resource-management.html
+
 ```js
-pool.acquire(function (error, connection) {
-  if (error != null) {
-    return handleError(error)
-  }
+// Don't do this! Leaks resources!
+pool.acquire().then(function (connection) {
   r.table('aTable').limit(10).run(connection, function (error, cursor) {
     if (error != null) {
       return handleError(error)

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "homepage": "https://github.com/hden/rethinkdb-pool",
   "dependencies": {
-    "debug": "^2.6.0",
-    "generic-pool": "^2.4.2"
+    "generic-pool": "^3.1.6"
   },
   "devDependencies": {
     "intelli-espower-loader": "^1.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ function isArray (o) {
   return toString.call(o) === '[object Array]'
 }
 
-describe('rethinkdb-pool', () => {
+describe('rethinkdb-pool', function () {
   var pool
 
   before(function () {
@@ -25,15 +25,14 @@ describe('rethinkdb-pool', () => {
     })
   })
 
-  after(() => {
+  after(function () {
     return pool.run(r.tableDrop('foo'))
   })
 
-  it('should acquire connection', (done) => {
-    pool.acquire((e, conn) => {
+  it('should acquire connection', function () {
+    return pool.acquire().then(function (conn) {
       assert.ok(conn)
-      pool.release(conn)
-      done()
+      return pool.release(conn)
     })
   })
 
@@ -49,19 +48,17 @@ describe('rethinkdb-pool', () => {
     })
   })
 
-  it('should query with callback', function (done) {
-    pool.run(r.table('foo'), function (e, result) {
+  it('should query with callback', function () {
+    return pool.run(r.table('foo'), function (e, result) {
       assert(result)
       assert(isArray(result))
-      done()
     })
   })
 
-  it('should query with options and callback', function (done) {
-    pool.run(r.table('foo'), { readMode: 'majority' }, function (e, result) {
+  it('should query with options and callback', function () {
+    return pool.run(r.table('foo'), { readMode: 'majority' }, function (e, result) {
       assert(result)
       assert(isArray(result))
-      done()
     })
   })
 


### PR DESCRIPTION
The `log`option  is deprecated by generic-pool v3 [[source](https://gist.github.com/sandfox/5ca20648b60a0cb959638c0cd6fcd02d)], otherwise no breaking changes have been introduced.

Fix #18 